### PR TITLE
[RT-1773] If the top tabs get swiped fast enough, the new selected tab will show blank

### DIFF
--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -251,9 +251,9 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
             let pageOffsetForChild = self.pageOffsetForChild(at: index)
             let offsetDifference = fabs(containerView.contentOffset.x - pageOffsetForChild)
             if offsetDifference < containerView.bounds.width {
-                // if the scroll offset doesn't pass exactly on the exact "destination" view controller's offset, we
-                // need to trigger the final state condition, and then trigger the start of a new transition from the
-                // current presenting index to the new presenting index
+                // if the scroll offset doesn't pass EXACTLY on the exact "destination" view controller's offset, we
+                // need to trigger the final state condition, and then trigger the start of a new transition from a
+                // new dismissing index to the new presenting one
                 let shouldSwitchTransition = viewControllerDismissingIndex != nil &&
                     index != viewControllerDismissingIndex && index != viewControllerPresentingIndex
                 if offsetDifference == 0 || shouldSwitchTransition {


### PR DESCRIPTION
So the issue was in how the container view controller was orchestrating the presentation and dismissing of child view controllers. Basically, it needed a zero difference between the destination view controller's x offset and the scrolling offset to mark the transition as done. The fix consists in also detect when the scroll passed that point, and executing the transition completion, and the start of a new one.

Another change I made was to not remove child view controllers' view from the scroll view, so swiping takes a little less time / is smoother.