### PR TITLE
[RT-1838] wrong view controller gets displayed when swiping

### DIFF
--- a/Sources/PagerTabStripViewController.swift
+++ b/Sources/PagerTabStripViewController.swift
@@ -267,11 +267,19 @@ open class PagerTabStripViewController: UIViewController, UIScrollViewDelegate {
                     // start/in-progress state
                     onScreenViewControllerIndexes.append(index)
                 }
-            } else if childController.parent != nil && index != viewControllerDismissingIndex {
-                childController.willMove(toParentViewController: nil)
-                childController.beginAppearanceTransition(false, animated: false)
-                childController.endAppearanceTransition()
-                childController.removeFromParentViewController()
+                if childController.isViewLoaded {
+                    childController.view.isHidden = false
+                }
+            } else if index != viewControllerDismissingIndex {
+                if childController.parent != nil {
+                    childController.willMove(toParentViewController: nil)
+                    childController.beginAppearanceTransition(false, animated: false)
+                    childController.endAppearanceTransition()
+                    childController.removeFromParentViewController()
+                }
+                if childController.isViewLoaded {
+                   childController.view.isHidden = true
+                }
             }
         }
         


### PR DESCRIPTION
Fixed bug where because not removing view controllers from the scroll view, they were appearing on top of the correct ones.